### PR TITLE
--pretty now gives times in UTC only

### DIFF
--- a/bin/influxdb-cli
+++ b/bin/influxdb-cli
@@ -20,7 +20,7 @@ class InfluxDBClientTasks < Thor
   method_option :username,  :default => 'root',       :desc => 'Username', :aliases => '-u'
   method_option :password,  :default => 'root',       :desc => 'Password', :aliases => '-p'
   method_option :database,  :default => 'db',         :desc => 'Database', :aliases => '-d'
-  method_option :pretty,    :default => nil,          :desc => 'Human readable times'
+  method_option :pretty,    :default => nil,          :desc => 'Human readable times (UTC)'
 
   def db
     puts "Connecting to #{options.inspect}"

--- a/lib/influxdb_client/client.rb
+++ b/lib/influxdb_client/client.rb
@@ -48,7 +48,7 @@ module InfluxDBClient
     def self.generate_table(series, result_series)
       headings = result_series.first.keys
       rows = result_series.map do |row|
-        row['time'] = Time.at(row['time'] / 1000).to_s if @pretty
+        row['time'] = Time.at(row['time'] / 1000).utc.to_s if @pretty
         row.values
       end
 

--- a/spec/influxdb_client/client_spec.rb
+++ b/spec/influxdb_client/client_spec.rb
@@ -56,10 +56,10 @@ module InfluxDBClient
         after(:all)  { described_class.pretty = false }
         it 'generates tables' do
           expect(Terminal::Table).to receive(:new).
-            with(title: :series1, headings: %w[time value1 value2], rows: [[include('2013-12-17 11:42:03'), 1, 2]])
+            with(title: :series1, headings: %w[time value1 value2], rows: [[include('2013-12-17 13:42:03 UTC'), 1, 2]])
 
           expect(Terminal::Table).to receive(:new).
-            with(title: :series2, headings: %w[time value3 value4 value5 value6], rows: [[include('2014-03-11 12:40:47'), 3, 4, nil, nil], [include('2014-03-12 19:45:58'), nil, 4, 5, 6]])
+            with(title: :series2, headings: %w[time value3 value4 value5 value6], rows: [[include('2014-03-11 15:40:47 UTC'), 3, 4, nil, nil], [include('2014-03-12 22:45:58 UTC'), nil, 4, 5, 6]])
 
           described_class.print_tabularize(result)
         end


### PR DESCRIPTION
As discussed in #4, this now just shows times in UTC timezone rather than localtime, when using --pretty. Specs pass locally, hopefully travis will be happy now too. 
