### PR TITLE
Specify encoding to avoid invalid multibyte errors

### DIFF
--- a/bin/influxdb-cli
+++ b/bin/influxdb-cli
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 
 require 'rubygems'
 require 'influxdb'


### PR DESCRIPTION
This will fix the "invalid multibyte char (US-ASCII)" error I got when running it in cygwin with Ruby 1.9

$ influxdb-cli
/usr/bin/influxdb-cli:23:in `load': /usr/lib/ruby/gems/1.9.1/gems/influxdb-cli-0.1.2/bin/influxdb-cli:30: invalid multibyte char (US-ASCII) (SyntaxError)
/usr/lib/ruby/gems/1.9.1/gems/influxdb-cli-0.1.2/bin/influxdb-cli:30: invalid multibyte char (US-ASCII)
/usr/lib/ruby/gems/1.9.1/gems/influxdb-cli-0.1.2/bin/influxdb-cli:30: syntax error, unexpected $end, expecting keyword_end
    puts '? ready'
            ^
        from /usr/bin/influxdb-cli:23:in`<main>'
