### PR TITLE
fixed pretty printing

### DIFF
--- a/bin/influxdb-cli
+++ b/bin/influxdb-cli
@@ -16,13 +16,13 @@ class InfluxDBClientTasks < Thor
   @@db = nil
 
   desc 'db', 'Connect to InfluxDB (default command)'
-  method_option :host,      :default => 'localhost',  :desc => 'Hostname'
-  method_option :port,      :default => 8086,         :desc => 'Port'
-  method_option :username,  :default => 'root',       :desc => 'Username', :aliases => '-u'
-  method_option :password,  :default => 'root',       :desc => 'Password', :aliases => '-p'
-  method_option :database,  :default => 'db',         :desc => 'Database', :aliases => '-d'
-  method_option :pretty,    :default => nil,          :desc => 'Human readable times (UTC)'
-  method_option :ssl,       :default => false,        :desc => 'Connect using TLS/SSL', :type => :boolean
+  method_option :host,     default: 'localhost', desc: 'Hostname'
+  method_option :port,     default: 8086,        desc: 'Port'
+  method_option :username, default: 'root',      desc: 'Username', aliases: '-u'
+  method_option :password, default: 'root',      desc: 'Password', aliases: '-p'
+  method_option :database, default: 'db',        desc: 'Database', aliases: '-d'
+  method_option :pretty,   default: nil,         desc: 'Human readable times (UTC)'
+  method_option :ssl,      default: false,       desc: 'Connect using TLS/SSL', type: :boolean
 
   def db
     puts "Connecting to #{options.inspect}"
@@ -65,7 +65,7 @@ Pry::Commands.block_command InfluxDBClient::Client::QUERY_LANGUAGE_MATCHER, 'Exe
   result    = db.query(query)
   duration  = Time.now - start
 
-  InfluxDBClient::Client.print_tabularize(result)
+  InfluxDBClient::Client.print_tabularize(result, db.time_precision)
 
   # print query duration in seconds
   puts "Query duration: #{duration.round(2)}s"
@@ -81,4 +81,3 @@ Pry.config.print = proc { |output, value| Pry::Helpers::BaseHelpers.stagger_outp
 
 # TODO start `pry` only in case of `db` command, `help` and `version` should not start `pry`
 pry
-

--- a/lib/influxdb_client/client.rb
+++ b/lib/influxdb_client/client.rb
@@ -10,7 +10,7 @@ module InfluxDBClient
     # @param result [Hash] the {InfluDB::Client#query result}
     # @param output [STDOUT] the output to `puts` the results
     # @return [Hash] the number of points per time series i.e. { 'response_times.count' => 10 }
-    def self.print_tabularize(result, output=$stdout)
+    def self.print_tabularize(result, time_precision, output=$stdout)
       result ||= {}
 
       if result.keys.empty?
@@ -21,8 +21,10 @@ module InfluxDBClient
       result.keys.each do |series|
         result_series = result[series]
         if result_series.any?
-          output.puts generate_table(series, result_series)
-          output.puts "#{result_series.size} #{pluralize(result_series.size, 'result')} found for #{series}"
+          output.puts generate_table(series, result_series, time_precision)
+          output.puts "#{result_series.size} " \
+                      "#{pluralize(result_series.size, 'result')} " \
+                      "found for #{series}"
         else
           output.puts "No results found for #{series}"
         end
@@ -45,12 +47,18 @@ module InfluxDBClient
       end
     end
 
-    def self.generate_table(series, result_series)
+    def self.generate_table(series, result_series, time_precision)
       headings = result_series.first.keys
+      precision_factor, str_format = case time_precision.to_s
+      when 's'  then [1.0, '%F %T']
+      when 'ms' then [1_000.0, '%F %T.%3N']
+      when 'u'  then [1_000_000.0, '%F %T.%6N']
+      else raise "unknown time_precision #{time_precision}"
+      end
       rows = result_series.map do |row|
         if @pretty
-          microseconds_with_frac = "#{row['time'] / 1000}.#{row['time'] % 100}".to_f
-          row['time'] = Time.at(microseconds_with_frac).utc.strftime('%Y-%m-%d %H:%M:%S.%L')
+          seconds_with_frac = row['time'].to_f / precision_factor
+          row['time'] = Time.at(seconds_with_frac).utc.strftime(str_format)
         end
         row.values
       end
@@ -59,4 +67,3 @@ module InfluxDBClient
     end
   end
 end
-


### PR DESCRIPTION
Pretty printed timestamps now correctly display depending on the time_precision set in the `@@db` object.
Additionally I removed some rspec deprecation warnings and replaced usage of old hash syntax.

This fixes issue #8 
