### PR TITLE
supports specifying alternative time_precision

### DIFF
--- a/bin/influxdb-cli
+++ b/bin/influxdb-cli
@@ -16,13 +16,14 @@ class InfluxDBClientTasks < Thor
   @@db = nil
 
   desc 'db', 'Connect to InfluxDB (default command)'
-  method_option :host,     default: 'localhost', desc: 'Hostname'
-  method_option :port,     default: 8086,        desc: 'Port'
-  method_option :username, default: 'root',      desc: 'Username', aliases: '-u'
-  method_option :password, default: 'root',      desc: 'Password', aliases: '-p'
-  method_option :database, default: 'db',        desc: 'Database', aliases: '-d'
-  method_option :pretty,   default: nil,         desc: 'Human readable times (UTC)'
-  method_option :ssl,      default: false,       desc: 'Connect using TLS/SSL', type: :boolean
+  method_option :host,           default: 'localhost', desc: 'Hostname'
+  method_option :port,           default: 8086,        desc: 'Port'
+  method_option :username,       default: 'root',      desc: 'Username', aliases: '-u'
+  method_option :password,       default: 'root',      desc: 'Password', aliases: '-p'
+  method_option :database,       default: 'db',        desc: 'Database', aliases: '-d'
+  method_option :pretty,         default: nil,         desc: 'Human readable times (UTC)'
+  method_option :ssl,            default: false,       desc: 'Connect using TLS/SSL', type: :boolean
+  method_option :time_precision, default: 's',         desc: 'Time precision ("s", "ms", "u")'
 
   def db
     puts "Connecting to #{options.inspect}"
@@ -32,7 +33,8 @@ class InfluxDBClientTasks < Thor
         password: options[:password],
         host: options[:host],
         port: options[:port],
-        use_ssl: options[:ssl]
+        use_ssl: options[:ssl],
+        time_precision: options[:time_precision]
       }
     InfluxDBClient::Client.pretty = options[:pretty]
     puts '✔ ready'
@@ -57,6 +59,7 @@ InfluxDBClientTasks.start
 
 # exit if the db command wasn't called
 exit 0 unless db
+
 
 # allow typing queries directly from console i.e.`select * from deploys` instead of `query('select * from deploys')`.
 # matches `delete from ...` and `select ... from ...`


### PR DESCRIPTION
You can now specify the time resolution for queries and writing points using the `--time_precision s|ms|u` flag. 

Eg:

```
$ be bin/influxdb-cli db --time_precision u --pretty
Connecting to {"host"=>"localhost", "port"=>8086, "username"=>"root", "password"=>"root", "database"=>"db", "ssl"=>false, "time_precision"=>"u", "pretty"=>"pretty"}
✔ ready
[1] pry(main)> use test
[2] pry(main)> SELECT * FROM /.*/ LIMIT 1
+----------------------------+-----------------+-------------+
|                            test                            |
+----------------------------+-----------------+-------------+
| time                       | sequence_number | message     |
+----------------------------+-----------------+-------------+
| 2014-12-19 05:46:41.787520 | 10001           | Hello Pablo |
+----------------------------+-----------------+-------------+
1 result found for test

Query duration: 0.0s
[3] pry(main)> quit
```
